### PR TITLE
Use async fs methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ dist
 lib/
 *.swp
 *.swo
+/temp

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -204,7 +204,7 @@ export class TrzszFilter {
     if (items instanceof DataTransferItemList) {
       this.uploadFilesList = await parseDataTransferItemList(items as DataTransferItemList);
     } else if (isArrayOfType(items, "string") && !isRunningInBrowser) {
-      this.uploadFilesList = nodefs.checkPathsReadable(items as string[], true);
+      this.uploadFilesList = await nodefs.checkPathsReadable(items as string[], true);
     } else {
       throw new Error("The upload items type is not supported");
     }
@@ -342,7 +342,7 @@ export class TrzszFilter {
         await this.trzszTransfer.sendAction(false, remoteIsWindows);
         return;
       }
-      nodefs.checkPathWritable(savePath);
+      await nodefs.checkPathWritable(savePath);
       saveParam = { path: savePath, maps: new Map<string, string>() };
       openSaveFile = nodefs.openSaveFile;
     }
@@ -368,7 +368,7 @@ export class TrzszFilter {
       sendFiles = directory ? await browser.selectSendDirectories() : await browser.selectSendFiles();
     } else {
       const filePaths = await this.chooseSendFiles(directory);
-      sendFiles = nodefs.checkPathsReadable(filePaths, directory);
+      sendFiles = await nodefs.checkPathsReadable(filePaths, directory);
     }
 
     if (!sendFiles || !sendFiles.length) {

--- a/src/nodefs.ts
+++ b/src/nodefs.ts
@@ -48,7 +48,7 @@ promisify(
   ]
 );
 
-function fsExists (fp: string) {
+function fsExistsAsync (fp: string) {
   return fs.accessAsync(fp)
     .then(() => true)
     .catch(() => false)
@@ -59,7 +59,7 @@ export async function checkPathWritable(filePath: string) {
     return false;
   }
 
-  if (!await fsExists(filePath)) {
+  if (!await fsExistsAsync(filePath)) {
     throw new TrzszError(`No such directory: ${filePath}`);
   }
   const stats = await fs.statAsync(filePath);
@@ -177,7 +177,7 @@ export async function checkPathsReadable(
   const entries = filePaths.entries()
   for (const [idx, filePath] of entries) {
     const absPath = path.resolve(filePath);
-    if (!await fsExists(absPath)) {
+    if (!await fsExistsAsync(absPath)) {
       throw new TrzszError(`No such file: ${absPath}`);
     }
     const stats = await fs.statAsync(absPath);
@@ -232,19 +232,19 @@ class NodefsFileWriter implements TrzszFileWriter {
 }
 
 async function getNewName(savePath: string, fileName: string) {
-  if (!fsExists(path.join(savePath, fileName))) {
+  if (!fsExistsAsync(path.join(savePath, fileName))) {
     return fileName;
   }
   for (let i = 0; i < 1000; i++) {
     const saveName = `${fileName}.${i}`;
-    if (!await fsExists(path.join(savePath, saveName))) {
+    if (!await fsExistsAsync(path.join(savePath, saveName))) {
       return saveName;
     }
   }
   throw new TrzszError("Fail to assign new file name");
 }
 
-async function doCreateFile(absPath: string) {
+function doCreateFile(absPath: string) {
   try {
     return fs.openAsync(absPath, "w");
   } catch (err) {
@@ -258,7 +258,7 @@ async function doCreateFile(absPath: string) {
 }
 
 async function doCreateDirectory(absPath: string) {
-  if (!await fsExists(absPath)) {
+  if (!await fsExistsAsync(absPath)) {
     await fs.mkdirAsync(absPath, { recursive: true, mode: 0o755 });
   }
   const stats = await fs.statAsync(absPath);

--- a/src/nodefs.ts
+++ b/src/nodefs.ts
@@ -6,7 +6,8 @@
 
 /* eslint-disable require-jsdoc */
 
-const fs = requireSafely("fs");
+const fs = requireSafely("fs/promises");
+const fso = requireSafely("fs");
 const path = requireSafely("path");
 import { TrzszError, TrzszFileReader, TrzszFileWriter } from "./comm";
 
@@ -18,20 +19,24 @@ function requireSafely(name) {
   }
 }
 
-export function checkPathWritable(filePath: string) {
+function checkExist (path: string) {
+  return fs.access(path).then(() => true).catch(() => false);
+}
+
+export async function checkPathWritable(filePath: string) {
   if (!filePath) {
     return false;
   }
 
-  if (!fs.existsSync(filePath)) {
+  if (!await checkExist(filePath)) {
     throw new TrzszError(`No such directory: ${filePath}`);
   }
-  const stats = fs.statSync(filePath);
+  const stats = await fs.stat(filePath);
   if (!stats.isDirectory()) {
     throw new TrzszError(`Not a directory: ${filePath}`);
   }
   try {
-    fs.accessSync(filePath, fs.constants.W_OK);
+    fs.access(filePath, fs.constants.W_OK);
   } catch (err) {
     throw new TrzszError(`No permission to write: ${filePath}`);
   }
@@ -77,25 +82,25 @@ class NodefsFileReader implements TrzszFileReader {
       throw new TrzszError(`File closed: ${this.absPath}`, null, true);
     }
     if (this.fd === null) {
-      this.fd = fs.openSync(this.absPath, "r");
+      this.fd = await fso.openSync(this.absPath, "r");
     }
     const uint8 = new Uint8Array(buf);
-    const n = fs.readSync(this.fd, uint8, 0, uint8.length, null);
+    const n = await fso.readSync(this.fd, uint8, 0, uint8.length, null);
     return uint8.subarray(0, n);
   }
 
-  public closeFile() {
+  public async closeFile() {
     if (!this.closed) {
       this.closed = true;
       if (this.fd !== null) {
-        fs.closeSync(this.fd);
+        await fso.closeSync(this.fd);
         this.fd = null;
       }
     }
   }
 }
 
-function checkPathReadable(
+async function checkPathReadable(
   pathId: number,
   absPath: string,
   stats: any,
@@ -108,7 +113,7 @@ function checkPathReadable(
       throw new TrzszError(`Not a regular file: ${absPath}`);
     }
     try {
-      fs.accessSync(absPath, fs.constants.R_OK);
+      await fs.access(absPath, fs.constants.R_OK);
     } catch (err) {
       throw new TrzszError(`No permission to read: ${absPath}`);
     }
@@ -116,38 +121,40 @@ function checkPathReadable(
     return;
   }
 
-  const realPath = fs.realpathSync(absPath);
+  const realPath = await fs.realpath(absPath);
   if (visitedDir.has(realPath)) {
     throw new TrzszError(`Duplicate link: ${absPath}`);
   }
   visitedDir.add(realPath);
   fileList.push(new NodefsFileReader(pathId, absPath, relPath, true, 0));
-
-  fs.readdirSync(absPath).forEach((file) => {
+  const arr = await fs.readdir(absPath)
+  for (const file of arr) {
     const filePath = path.join(absPath, file);
-    checkPathReadable(pathId, filePath, fs.statSync(filePath), fileList, [...relPath, file], visitedDir);
-  });
+    const stat = await fs.stat(filePath)
+    await checkPathReadable(pathId, filePath, stat, fileList, [...relPath, file], visitedDir);
+  }
 }
 
-export function checkPathsReadable(
+export async function checkPathsReadable(
   filePaths: string[] | undefined,
   directory: boolean = false
-): TrzszFileReader[] | undefined {
+): Promise<TrzszFileReader[] | undefined> {
   if (!filePaths || !filePaths.length) {
     return undefined;
   }
   const fileList: NodefsFileReader[] = [];
-  for (const [idx, filePath] of filePaths.entries()) {
+  const entries = filePaths.entries()
+  for (const [idx, filePath] of entries) {
     const absPath = path.resolve(filePath);
-    if (!fs.existsSync(absPath)) {
+    if (!await checkExist(absPath)) {
       throw new TrzszError(`No such file: ${absPath}`);
     }
-    const stats = fs.statSync(absPath);
+    const stats = await fs.stat(absPath);
     if (!directory && stats.isDirectory()) {
       throw new TrzszError(`Is a directory: ${absPath}`);
     }
     const visitedDir = new Set<string>();
-    checkPathReadable(idx, absPath, stats, fileList, [path.basename(absPath)], visitedDir);
+    await checkPathReadable(idx, absPath, stats, fileList, [path.basename(absPath)], visitedDir);
   }
   return fileList;
 }
@@ -179,36 +186,36 @@ class NodefsFileWriter implements TrzszFileWriter {
   }
 
   public async writeFile(buf: Uint8Array) {
-    fs.writeSync(this.fd, buf);
+    await fs.writeSync(this.fd, buf);
   }
 
-  public closeFile() {
+  public async closeFile() {
     if (!this.closed) {
       this.closed = true;
       if (this.fd !== null) {
-        fs.closeSync(this.fd);
+        await fso.closeSync(this.fd);
         this.fd = null;
       }
     }
   }
 }
 
-function getNewName(savePath: string, fileName: string) {
-  if (!fs.existsSync(path.join(savePath, fileName))) {
+async function getNewName(savePath: string, fileName: string) {
+  if (!checkExist(path.join(savePath, fileName))) {
     return fileName;
   }
   for (let i = 0; i < 1000; i++) {
     const saveName = `${fileName}.${i}`;
-    if (!fs.existsSync(path.join(savePath, saveName))) {
+    if (!await checkExist(path.join(savePath, saveName))) {
       return saveName;
     }
   }
   throw new TrzszError("Fail to assign new file name");
 }
 
-function doCreateFile(absPath: string) {
+async function doCreateFile(absPath: string) {
   try {
-    return fs.openSync(absPath, "w");
+    return fso.openSync(absPath, "w");
   } catch (err) {
     if (err.errno === -13 || err.errno === -4048) {
       throw new TrzszError(`No permission to write: ${absPath}`);
@@ -219,19 +226,19 @@ function doCreateFile(absPath: string) {
   }
 }
 
-function doCreateDirectory(absPath: string) {
-  if (!fs.existsSync(absPath)) {
-    fs.mkdirSync(absPath, { recursive: true, mode: 0o755 });
+async function doCreateDirectory(absPath: string) {
+  if (!await checkExist(absPath)) {
+    await fs.mkdir(absPath, { recursive: true, mode: 0o755 });
   }
-  const stats = fs.statSync(absPath);
+  const stats = await fs.stat(absPath);
   if (!stats.isDirectory()) {
     throw new TrzszError(`Not a directory: ${absPath}`);
   }
 }
 
-function createFile(savePath, fileName: string, overwrite: boolean) {
-  const localName = overwrite ? fileName : getNewName(savePath, fileName);
-  const fd = doCreateFile(path.join(savePath, localName));
+async function createFile(savePath, fileName: string, overwrite: boolean) {
+  const localName = overwrite ? fileName : await getNewName(savePath, fileName);
+  const fd = await doCreateFile(path.join(savePath, localName));
   return new NodefsFileWriter(fileName, localName, fd);
 }
 
@@ -258,7 +265,7 @@ export async function openSaveFile(saveParam: any, fileName: string, directory: 
     if (saveParam.maps.has(file.path_id)) {
       localName = saveParam.maps.get(file.path_id);
     } else {
-      localName = getNewName(saveParam.path, file.path_name[0]);
+      localName = await getNewName(saveParam.path, file.path_name[0]);
       saveParam.maps.set(file.path_id, localName);
     }
   }
@@ -266,17 +273,17 @@ export async function openSaveFile(saveParam: any, fileName: string, directory: 
   let fullPath: string;
   if (file.path_name.length > 1) {
     const p = path.join(saveParam.path, localName, ...file.path_name.slice(1, file.path_name.length - 1));
-    doCreateDirectory(p);
+    await doCreateDirectory(p);
     fullPath = path.join(p, fileName);
   } else {
     fullPath = path.join(saveParam.path, localName);
   }
 
   if (file.is_dir === true) {
-    doCreateDirectory(fullPath);
+    await doCreateDirectory(fullPath);
     return new NodefsFileWriter(fileName, localName, null, true);
   }
 
-  const fd = doCreateFile(fullPath);
+  const fd = await doCreateFile(fullPath);
   return new NodefsFileWriter(fileName, localName, fd);
 }

--- a/src/trz.ts
+++ b/src/trz.ts
@@ -108,7 +108,7 @@ async function main() {
 
   try {
     args.path = path.resolve(args.path);
-    nodefs.checkPathWritable(args.path);
+    await nodefs.checkPathWritable(args.path);
 
     const [tmuxMode, realStdoutWriter, tmuxPaneWidth] = await checkTmux();
 

--- a/src/tsz.ts
+++ b/src/tsz.ts
@@ -110,7 +110,7 @@ async function main() {
   const args = parseArgs();
 
   try {
-    const fileList = checkPathsReadable(args.file, args.directory);
+    const fileList = await checkPathsReadable(args.file, args.directory);
     if (!fileList) {
       return;
     }


### PR DESCRIPTION
- Tested in electerm, tsz/trz all works, 
- fs.open/fs.write/fs.read still use fs namespace function and sync function, but use await, so we can support pure async env like browser, since we need number type fileHandle, others functions use fs/promises.
- Many tests can not pass, not if it is brought by this PR